### PR TITLE
Add sentiment chat bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ These data are reused by various widely used opensource projects, among which Wi
 ### License 
 MIT License for code.<br>
 CC-by-sa-4.0 for content.
+
+## Sentiment Chat Bot
+
+A simple real-time sentiment analysis chat bot is included in `sentiment_chat_bot`.
+It uses Flask and the `vaderSentiment` library to analyze user messages.
+
+### Usage
+1. Install dependencies:
+   ```bash
+   pip install Flask vaderSentiment
+   ```
+2. Run the application:
+   ```bash
+   python3 sentiment_chat_bot/app.py
+   ```
+3. Open your browser at `http://localhost:5000` and start chatting. Messages are saved to `chat_history.json`.

--- a/sentiment_chat_bot/app.py
+++ b/sentiment_chat_bot/app.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+from flask import Flask, render_template, request, jsonify
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+app = Flask(__name__)
+
+CHAT_HISTORY_FILE = Path(__file__).with_name('chat_history.json')
+analyzer = SentimentIntensityAnalyzer()
+
+# load existing chat history
+if CHAT_HISTORY_FILE.exists():
+    with open(CHAT_HISTORY_FILE, 'r', encoding='utf-8') as f:
+        chat_history = json.load(f)
+else:
+    chat_history = []
+
+def save_history():
+    with open(CHAT_HISTORY_FILE, 'w', encoding='utf-8') as f:
+        json.dump(chat_history, f, ensure_ascii=False, indent=2)
+
+@app.route('/')
+def index():
+    return render_template('index.html', history=chat_history)
+
+@app.route('/analyze', methods=['POST'])
+def analyze():
+    text = request.json.get('text', '')
+    sentiment = analyzer.polarity_scores(text)
+    compound = sentiment['compound']
+    if compound >= 0.05:
+        mood = 'positive'
+        emoji = '😊'
+        response = 'Great to hear!'
+    elif compound <= -0.05:
+        mood = 'negative'
+        emoji = '😟'
+        response = 'I\'m sorry to hear that.'
+    else:
+        mood = 'neutral'
+        emoji = '😐'
+        response = 'Thanks for sharing.'
+
+    entry = {'text': text, 'mood': mood, 'emoji': emoji, 'response': response}
+    chat_history.append(entry)
+    save_history()
+    return jsonify(entry)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/sentiment_chat_bot/templates/index.html
+++ b/sentiment_chat_bot/templates/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Sentiment Chat Bot</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #chat { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+        .message { margin-bottom: 10px; }
+        .positive { color: green; }
+        .negative { color: red; }
+        .neutral { color: gray; }
+    </style>
+</head>
+<body>
+    <h1>Real-time Sentiment Chat Bot</h1>
+    <div id="chat">
+        {% for item in history %}
+        <div class="message {{ item.mood }}">
+            <strong>You:</strong> {{ item.text }} {{ item.emoji }}<br/>
+            <em>Bot:</em> {{ item.response }}
+        </div>
+        {% endfor %}
+    </div>
+    <input type="text" id="userInput" placeholder="Type your message" style="width:80%"/>
+    <button onclick="send()">Send</button>
+
+    <script>
+    async function send() {
+        const text = document.getElementById('userInput').value;
+        if (!text) return;
+        const response = await fetch('/analyze', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text })
+        });
+        const data = await response.json();
+        const div = document.createElement('div');
+        div.className = 'message ' + data.mood;
+        div.innerHTML = `<strong>You:</strong> ${text} ${data.emoji}<br/><em>Bot:</em> ${data.response}`;
+        document.getElementById('chat').appendChild(div);
+        document.getElementById('userInput').value = '';
+        document.getElementById('chat').scrollTop = document.getElementById('chat').scrollHeight;
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple real-time sentiment analysis chat bot with Flask and Vader
- save and display chat history with mood-based color/emoji
- document how to run the chat bot in README

## Testing
- `python3 -m py_compile sentiment_chat_bot/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883b83bb8d083279baa034e3a14a358